### PR TITLE
Add Support for Setting Azure Location for Testing and Upload Pester Test Output Artefacts - Fixes #19 #20

### DIFF
--- a/.Build.ps1
+++ b/.Build.ps1
@@ -104,8 +104,7 @@ Add-BuildTask LintUnitTests {
     $Pester = Invoke-Pester -Tag Lint, Unit -OutputFormat NUnitXml -OutputFile `
         $testResultsFile -PassThru
     
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -212,8 +211,7 @@ Add-BuildTask IntegrationTestAzureAutomationDSC {
     $Pester = Invoke-Pester -Tag AADSCIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
     
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -240,8 +238,7 @@ Add-BuildTask IntegrationTestAzureVMs {
     $Pester = Invoke-Pester -Tag AzureVMIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
     
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
 
     $host.SetShouldExit($Pester.FailedCount)
 }

--- a/.Build.ps1
+++ b/.Build.ps1
@@ -104,6 +104,9 @@ Add-BuildTask LintUnitTests {
     $Pester = Invoke-Pester -Tag Lint, Unit -OutputFormat NUnitXml -OutputFile `
         $testResultsFile -PassThru
     
+    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+    (Resolve-Path $testResultsFile))
+
     Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)
@@ -210,7 +213,10 @@ Add-BuildTask IntegrationTestAzureAutomationDSC {
     $testResultsFile = "$env:BuildFolder\AADSCIntegrationTestsResults.xml"
     $Pester = Invoke-Pester -Tag AADSCIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
-    
+
+    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+    (Resolve-Path $testResultsFile))
+
     Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)
@@ -237,7 +243,10 @@ Add-BuildTask IntegrationTestAzureVMs {
 
     $Pester = Invoke-Pester -Tag AzureVMIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
-    
+
+    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+    (Resolve-Path $testResultsFile))
+
     Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)

--- a/.Build.ps1
+++ b/.Build.ps1
@@ -104,7 +104,7 @@ Add-BuildTask LintUnitTests {
     $Pester = Invoke-Pester -Tag Lint, Unit -OutputFormat NUnitXml -OutputFile `
         $testResultsFile -PassThru
     
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -211,7 +211,7 @@ Add-BuildTask IntegrationTestAzureAutomationDSC {
     $Pester = Invoke-Pester -Tag AADSCIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
     
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -238,7 +238,7 @@ Add-BuildTask IntegrationTestAzureVMs {
     $Pester = Invoke-Pester -Tag AzureVMIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
     
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile))
+    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
 
     $host.SetShouldExit($Pester.FailedCount)
 }

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ on Azure.
   by defining the `$ENV:Location` environment variable. Will default
   to 'EastUS2' if not specified.
 * NUnit Pester Test results uploaded to AppVeyor as artifacts.
+* Updated `New-ResourceGroupandAutomationAccount` to automatically
+  register `Microsoft.Automation` resource provider.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # DSCConfiguration.Tests
 
-This repo provides test automation scripting that are intended to accelerate iterative authoring of DSC Configurations by hosting tests on Azure.
+This repository provides test automation scripting that are intended to
+accelerate iterative authoring of DSC Configurations by hosting tests
+on Azure.
+
+## Versions
+
+### Unreleased
+
+* README.MD:
+  * Fixed markdown rule violations.
+  * Added Change Log.
+* Added support for specifying the Azure Data center location to use
+  by defining the `$ENV:Location` environment variable. Will default
+  to 'EastUS2' if not specified.
+* NUnit Pester Test results uploaded to AppVeyor as artifacts.

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -242,12 +242,18 @@ function New-ResourceGroupandAutomationAccount
     (
         [string]$SubscriptionID = $env:SubscriptionID,
         [string]$TenantID = $env:TenantID,
-        [string]$Location = 'EastUS2',
+        [string]$Location = $env:Location,
         [string]$ResourceGroupName = 'TestAutomation'+$env:BuildID,
         [string]$AutomationAccountName = 'AADSC'+$env:BuildID
     )
     try 
     {
+        # Default the location to 'EastUS2' if not passed
+        If ([String]::IsNullOrEmpty($Location))
+        {
+            $Location = 'EastUS2'
+        }
+
         # Make sure subscription is selected
         $Subscription = Select-AzureRMSubscription -SubscriptionID $SubscriptionID `
         -TenantID $TenantID

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -256,12 +256,19 @@ function New-ResourceGroupandAutomationAccount
 
         # Make sure subscription is selected
         $Subscription = Select-AzureRMSubscription -SubscriptionID $SubscriptionID `
-        -TenantID $TenantID
+            -TenantID $TenantID
+
+        Write-Output "Registering 'Microsoft.Automation' resource provider"
+
+            # Ensure the Microsoft.Automation resource provider is registered
+        Register-AzureRmResourceProvider -ProviderNamespace 'Microsoft.Automation'
 
         # Create Resource Group
         $ResourceGroup = New-AzureRmResourceGroup -Name $ResourceGroupName -Location $Location `
-        -Force
+            -Force
+
         Write-Output "Provisioning of Resource Group $ResourceGroupName returned $($ResourceGroup.ProvisioningState)"
+
         # Validate provisioning of resource group
         $ResourceGroupExists = Get-AzureRmResourceGroup -Name $ResourceGroupName
         If ($Null -eq $ResourceGroupExists) {
@@ -270,11 +277,14 @@ function New-ResourceGroupandAutomationAccount
 
         # Create Azure Automation account
         $AutomationAccount = New-AzureRMAutomationAccount -ResourceGroupName $ResourceGroupName `
-        -Name $AutomationAccountName -Location $Location -Plan Basic
+            -Name $AutomationAccountName -Location $Location -Plan Basic
+
         Write-Output "Provisioning of Automation Account $AutomationAccountName returned $($AutomationAccount.State)"
+
         # Validate provisioning of resource group
         $AutomationAccountExists = Get-AzureRmAutomationAccount -ResourceGroupName $ResourceGroupName `
-        -Name $AutomationAccountName
+            -Name $AutomationAccountName
+
         If ($Null -eq $AutomationAccountExists) {
             throw "Automation account $AutomationAccountName could not be validated"
         }


### PR DESCRIPTION
This PR addresses:
 - Fixes #19 
 - Fixes #20 

The main issue I ran into when creating a config using this pattern was that my Azure subscription for some reason didn't allow me to create the VMs required to execute the automated tests in the default EastUS2 data center. So I needed a way to override the location.

I also find it useful to upload the Pester test results into AppVeyor as files I can download and distribute (as we do with DSC Resource Kit).

As I was also making changes to this, I thought a Changelog should also be included in the README.MD so I added one.

This PR changes:
* README.MD:
  * Fixed markdown rule violations.
  * Added Change Log.
* Added support for specifying the Azure Data center location to use
  by defining the `$ENV:Location` environment variable. Will default
  to 'EastUS2' if not specified.
* NUnit Pester Test results uploaded to AppVeyor as artifacts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscconfiguration.tests/21)
<!-- Reviewable:end -->
