### PR TITLE
Fixes issues with running test locally and in AppVeyor

### DIFF
--- a/.Build.ps1
+++ b/.Build.ps1
@@ -62,7 +62,7 @@ Enter-Build {
         'Pester',
         'PSScriptAnalyzer'
     )
-    Install-Module -Name $EnvironmentModules -Repository PSGallery -Force
+    Install-Module -Name $EnvironmentModules -Repository PSGallery -Force -SkipPublisherCheck
 
     # Fix module path if duplicates exist (TestHelper)
     Invoke-UniquePSModulePath

--- a/.Build.ps1
+++ b/.Build.ps1
@@ -43,7 +43,7 @@ Exit-BuildTask {
 #>
 Enter-Build {
     Write-Output "The build folder is $env:BuildFolder"
-    
+
     # Optimize timing for AzureRM module to install
     Write-Output "Installing latest AzureRM module as background job"
     $ARM = Start-Job -ScriptBlock {
@@ -52,7 +52,7 @@ Enter-Build {
 
     # Load helper module from test repo
     Import-Module -Name $env:BuildFolder\DscConfiguration.Tests\TestHelper.psm1 -Force
-    
+
     # Preload NuGet package provider
     $Nuget = Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.205 -Force
 
@@ -63,7 +63,7 @@ Enter-Build {
         'PSScriptAnalyzer'
     )
     Install-Module -Name $EnvironmentModules -Repository PSGallery -Force
-    
+
     # Fix module path if duplicates exist (TestHelper)
     Invoke-UniquePSModulePath
 }
@@ -103,11 +103,16 @@ Add-BuildTask LintUnitTests {
     $testResultsFile = "$env:BuildFolder\LintUnitTestsResults.xml"
     $Pester = Invoke-Pester -Tag Lint, Unit -OutputFormat NUnitXml -OutputFile `
         $testResultsFile -PassThru
-    
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
 
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+    if ($env:APPVEYOR -eq $true)
+    {
+        (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+        (Resolve-Path $testResultsFile))
+
+        Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+    }
+
+    Remove-Item $testResultsFile
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -118,7 +123,7 @@ Add-BuildTask LintUnitTests {
 Add-BuildTask AzureLogin {
     Write-Output "Waiting for AzureRM module to finish installing"
     $ARM = Wait-Job -Job $ARM
-    
+
     # Login to Azure using information from params
     Invoke-AzureSPNLogin
 }
@@ -147,7 +152,7 @@ Add-BuildTask AzureAutomationAssets {
         # Import the modules discovered as requirements to Azure Automation (TestHelper)
         foreach ($ImportModule in $Modules) {
             Import-ModuleToAzureAutomation -Module $ImportModule
-        }    
+        }
         # Allow module activities to extract before importing configuration (TestHelper)
         foreach ($WaitForModule in $Modules) {
             Wait-ModuleExtraction -Module $WaitForModule
@@ -170,17 +175,17 @@ Add-BuildTask AzureAutomationAssets {
 Add-BuildTask AzureVM {
     $Script:VMDeployments = @()
     Write-Output 'Deploying all test virtual machines in parallel'
-    
+
     ForEach ($Configuration in $script:Configurations) {
         ForEach ($WindowsOSVersion in $Configuration.WindowsOSVersion) {
-        
+
             If ($null -eq $WindowsOSVersion) {
                 Write-Output "No OS version was provided for deployment of $($Configuration.Name)"
             }
             Write-Output "Initiating background deployment of $WindowsOSVersion and bootstrapping configuration $($Configuration.Name)"
-        
+
             $JobName = "$($Configuration.Name).$($WindowsOSVersion.replace('-',''))"
-        
+
             $Script:VMDeployment = Start-Job -ScriptBlock {
                 param
                 (
@@ -188,9 +193,9 @@ Add-BuildTask AzureVM {
                     [string]$WindowsOSVersion
                 )
                 Import-Module -Name $env:BuildFolder\DscConfiguration.Tests\TestHelper.psm1 -Force
-            
+
                 Invoke-AzureSPNLogin
-            
+
                 New-AzureTestVM -Configuration $Configuration -WindowsOSVersion $WindowsOSVersion
 
             } -ArgumentList @($Configuration.Name, $WindowsOSVersion) -Name $JobName
@@ -214,10 +219,15 @@ Add-BuildTask IntegrationTestAzureAutomationDSC {
     $Pester = Invoke-Pester -Tag AADSCIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
 
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
+    if ($env:APPVEYOR -eq $true)
+    {
+        (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+        (Resolve-Path $testResultsFile))
 
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+        Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+    }
+
+    Remove-Item $testResultsFile
 
     $host.SetShouldExit($Pester.FailedCount)
 }
@@ -229,7 +239,7 @@ Add-BuildTask IntegrationTestAzureVMs {
     Write-Host "Waiting for all nodes to finish deployment"
     ForEach ($VMDeploymentJob in $Script:VMDeployments) {
         $Wait = Wait-Job -Job $VMDeploymentJob
-        
+
         Write-Output `n
         Write-Output "########## Output from $($VMDeploymentJob.Name) ##########"
         Receive-Job -Job $VMDeploymentJob
@@ -244,10 +254,15 @@ Add-BuildTask IntegrationTestAzureVMs {
     $Pester = Invoke-Pester -Tag AzureVMIntegration -OutputFormat NUnitXml `
         -OutputFile $testResultsFile -PassThru
 
-    (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
-    (Resolve-Path $testResultsFile))
+    if ($env:APPVEYOR -eq $true)
+    {
+        (New-Object 'System.Net.WebClient').UploadFile("$env:TestResultsUploadURI", `
+        (Resolve-Path $testResultsFile))
 
-    Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+        Push-AppveyorArtifact -Path (Resolve-Path $testResultsFile)
+    }
+
+    Remove-Item $testResultsFile
 
     $host.SetShouldExit($Pester.FailedCount)
 }

--- a/DSCConfiguration.Tests.ps1
+++ b/DSCConfiguration.Tests.ps1
@@ -161,7 +161,7 @@ Describe 'Common Tests - File Parsing' -Tag Lint {
 
     foreach ($ScriptFile in $ScriptFiles)
     {
-        Context $ScriptFile.Name {   
+        Context $ScriptFile.Name {
             It 'Should not contain parse errors' {
                 $containsParseErrors = $false
 
@@ -185,7 +185,7 @@ Describe 'Common Tests - File Parsing' -Tag Lint {
 #>
 Describe 'Common Tests - File Formatting' -Tag Lint {
     $textFiles = Get-TextFilesList -FilePath $env:BuildFolder
-    
+
     Context 'All discovered ext files' {
         It "Should not contain any files with Unicode file encoding" {
             $containsUnicodeFile = $false
@@ -261,12 +261,12 @@ Describe 'Common Tests - File Formatting' -Tag Lint {
                     }
 
                     Write-Warning -Message "$($textFile.FullName) does not end with a new line. Use fixer function 'Add-NewLine'"
-                    
+
                     $containsFileWithoutNewLine = $true
                 }
             }
 
-                    
+
             $containsFileWithoutNewLine | Should Be $false
         }
     }
@@ -328,7 +328,7 @@ Describe 'Common Tests - Configuration Module Requirements' -Tag Unit {
                 }
                 It "$($RequiredModule.ModuleName) version $($RequiredModule.ModuleVersion) should install locally without error" {
                     {Install-Module -Name $RequiredModule.ModuleName -RequiredVersion $RequiredModule.ModuleVersion -Force} | Should Not Throw
-                } 
+                }
             }
             else {
                 It "$RequiredModule should be found in the PowerShell public gallery" {
@@ -425,7 +425,7 @@ Describe 'Common Tests - Azure VM' -Tag AzureVMIntegration {
     $ConfigurationCommands = Get-Command -Type Configuration | Where-Object {$_.Source -eq ''} | ForEach-Object {$_.Name}
 
     $ProjectModuleName = -join ($env:ProjectName,'Module')
-    $OSVersion = (Import-PowerShellDataFile $env:BuildFolder\$ProjectModuleName\$ProjectModuleName.psd1).PrivateData.PSData.WindowsOSVersion
+    $OSVersion = (Import-PowerShellDataFile $env:BuildFolder\$ProjectModuleName\$ProjectModuleName.psd1).PrivateData.WindowsOSVersion
 
     $Nodes = Get-AzureRMAutomationDSCNode -ResourceGroupName $ResourceGroup -AutomationAccountName $AutomationAccount
     $NodeNames = $Nodes | ForEach-Object {$_.Name}
@@ -441,4 +441,4 @@ Describe 'Common Tests - Azure VM' -Tag AzureVMIntegration {
             }
         }
     }
-}    
+}

--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ on Azure.
 * NUnit Pester Test results uploaded to AppVeyor as artifacts.
 * Updated `New-ResourceGroupandAutomationAccount` to automatically
   register `Microsoft.Automation` resource provider.
+* Fixed so the correct path is used for property WindowsOSVersion in the module
+  manifest (issue #24).
+* Pester test result file is only uploaded if the test are running in AppVeyor
+  (issue #26).
+* The Pester test result file is removed after the file has been uploaded
+  (issue #26).
+* Fixed so that latest Pester version can be installed on a Windows 10 or
+  Windows Server 2016 where Pester module is signed (issue #29).
+* Fixed so that more than one required module can be loaded (issue #32).

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -2,12 +2,12 @@
     .SYNOPSIS
 
 #>
-function Invoke-UniquePSModulePath 
+function Invoke-UniquePSModulePath
 {
     [CmdletBinding()]
     param
-    () 
-    try 
+    ()
+    try
     {
         Write-Output 'Verifying there are no duplicates in PSModulePath'
         # Correct duplicates in environment psmodulepath
@@ -41,14 +41,14 @@ function Get-RequiredGalleryModules
         [switch]$Install
     )
     try {
-        # Load module data and create array of objects containing prerequisite details for use 
+        # Load module data and create array of objects containing prerequisite details for use
         # later in Azure Automation
         $ModulesInformation = @()
-        foreach($RequiredModule in $ManifestData.RequiredModules[0])
+        foreach($RequiredModule in $ManifestData.RequiredModules)
         {
             # Placeholder object to store module names and locations
             $ModuleReference = New-Object -TypeName PSObject
-            
+
             # If no version is given, get the latest version
             if ($RequiredModule.gettype().Name -eq 'String')
             {
@@ -100,9 +100,9 @@ function Get-RequiredGalleryModules
                 }
             }
         }
-        return $ModulesInformation    
+        return $ModulesInformation
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
         throw "An error occured while getting modules from PowerShellGallery.com`n$($_.exception.message)"
     }
@@ -114,13 +114,13 @@ function Get-RequiredGalleryModules
 #>
 function Import-ModuleFromSource
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
         [string]$Name
     )
-    try 
+    try
     {
         if ($ModuleDir = New-Item -Type Directory `
         -Path $env:ProgramFiles\WindowsPowerShell\Modules\$Name -force) {
@@ -131,7 +131,7 @@ function Import-ModuleFromSource
             Import-Module -Name $Name
         }
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
         throw "An error occured while importing module $Name`n$($_.exception.message)"
     }
@@ -143,14 +143,14 @@ function Import-ModuleFromSource
 #>
 function Invoke-ConfigurationPrep
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
         [string]$Module,
         [string]$Path = "$env:TEMP\DSCConfigurationScripts"
     )
-    try 
+    try
     {
         # Discover OS versions, or default to Server 2016 Datacenter Edition
         $WindowsOSVersion = if ($ModuleData = `
@@ -167,7 +167,7 @@ function Invoke-ConfigurationPrep
 
         # Create working folder
         New-Item -Path $Path -ItemType Directory -Force | Out-Null
-    
+
         # Create a unique script for each configuration, with a name that matches the configuration
         # this is a safeguard in case multiple configurations are given in a file
         foreach ($Configuration in $Configurations) {
@@ -183,7 +183,7 @@ function Invoke-ConfigurationPrep
         -Process {$_.Name})"
         return $Configurations
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
         throw "An error occured while preparing configurations for import`n$($_.exception.message)"
     }
@@ -203,19 +203,19 @@ function Invoke-AzureSPNLogin
         [string]$ApplicationPassword = $env:ApplicationPassword,
         [string]$TenantID = $env:TenantID
     )
-    try 
+    try
     {
         Write-Output "Logging in to Azure"
-        
+
         # Build platform (AppVeyor) does not offer solution for passing secure strings
         $Credential = New-Object -typename System.Management.Automation.PSCredential -argumentlist $ApplicationID, $(convertto-securestring -String $ApplicationPassword -AsPlainText -Force)
-    
+
         # Suppress request to share usage information
         $Path = "$Home\AppData\Roaming\Windows Azure Powershell\"
         if (!(Test-Path -Path $Path)) {
             $AzPSProfile = New-Item -Path $Path -ItemType Directory
         }
-        $AzProfileContent = Set-Content -Value '{"enableAzureDataCollection":true}' -Path (Join-Path $Path 'AzureDataCollectionProfile.json') 
+        $AzProfileContent = Set-Content -Value '{"enableAzureDataCollection":true}' -Path (Join-Path $Path 'AzureDataCollectionProfile.json')
 
         # Handle login
         $AddAccount = Add-AzureRmAccount -ServicePrincipal -SubscriptionID $SubscriptionID -TenantID $TenantID -Credential $Credential -ErrorAction SilentlyContinue
@@ -246,7 +246,7 @@ function New-ResourceGroupandAutomationAccount
         [string]$ResourceGroupName = 'TestAutomation'+$env:BuildID,
         [string]$AutomationAccountName = 'AADSC'+$env:BuildID
     )
-    try 
+    try
     {
         # Default the location to 'EastUS2' if not passed
         If ([String]::IsNullOrEmpty($Location))
@@ -300,7 +300,7 @@ function New-ResourceGroupandAutomationAccount
 #>
 function Import-ModuleToAzureAutomation
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
@@ -333,7 +333,7 @@ function Import-ModuleToAzureAutomation
 #>
 function Wait-ModuleExtraction
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
@@ -350,11 +350,11 @@ function Wait-ModuleExtraction
                 Start-Sleep -Seconds 15
         }
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
-        throw "An error occured while waiting for module $($Module.Name) activities to extract in Azure Automation`n$($_.exception.message)"        
+        throw "An error occured while waiting for module $($Module.Name) activities to extract in Azure Automation`n$($_.exception.message)"
     }
-}    
+}
 
 <#
     .SYNOPSIS
@@ -362,7 +362,7 @@ function Wait-ModuleExtraction
 #>
 function Import-ConfigurationToAzureAutomation
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
@@ -370,7 +370,7 @@ function Import-ConfigurationToAzureAutomation
         [string]$ResourceGroupName = 'TestAutomation'+$env:BuildID,
         [string]$AutomationAccountName = 'AADSC'+$env:BuildID
     )
-    try 
+    try
     {
         Write-Output "Importing configuration $($Configuration.Name) to Azure Automation"
         # Import Configuration to Azure Automation DSC
@@ -401,9 +401,9 @@ function Import-ConfigurationToAzureAutomation
     }
         $Compile = Start-AzureRmAutomationDscCompilationJob @CompileParams
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
-        throw "An error occured while importing the configuration $($Configuration.Name) using Azure Automation`n$($_.exception.message)"        
+        throw "An error occured while importing the configuration $($Configuration.Name) using Azure Automation`n$($_.exception.message)"
     }
 }
 
@@ -413,7 +413,7 @@ function Import-ConfigurationToAzureAutomation
 #>
 function Wait-ConfigurationCompilation
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
@@ -421,16 +421,16 @@ function Wait-ConfigurationCompilation
         [string]$ResourceGroupName = 'TestAutomation'+$env:BuildID,
         [string]$AutomationAccountName = 'AADSC'+$env:BuildID
     )
-    try 
+    try
     {
         while (@('Completed','Suspended') -notcontains (Get-AzureRmAutomationDscCompilationJob -ResourceGroupName $ResourceGroupName `
         -AutomationAccountName $AutomationAccountName -Name $Configuration.Name).Status) {
             Start-Sleep -Seconds 15
-        }   
+        }
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
-        throw "An error occured while waiting for configuration $($Configuration.Name) to compile in Azure Automation`n$($_.exception.message)"        
+        throw "An error occured while waiting for configuration $($Configuration.Name) to compile in Azure Automation`n$($_.exception.message)"
     }
 }
 
@@ -490,15 +490,15 @@ function New-RandomPassword
 #>
 function New-AzureTestVM
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory=$true)]
         [string]$Configuration,
-        [Parameter(Mandatory=$true)]        
+        [Parameter(Mandatory=$true)]
         [string]$WindowsOSVersion
     )
-    try 
+    try
     {
         # Retrieve Azure Automation DSC registration information
         $Account = Get-AzureRMAutomationAccount -ResourceGroupName "TestAutomation$env:BuildID" `
@@ -559,9 +559,9 @@ function New-AzureTestVM
             Write-Error $Message
         }
     }
-        catch [System.Exception] 
+        catch [System.Exception]
         {
-        throw "An error occured during the Azure deployment.`n$($_.exception.message)"        
+        throw "An error occured during the Azure deployment.`n$($_.exception.message)"
     }
 }
 
@@ -571,13 +571,13 @@ function New-AzureTestVM
 #>
 function Wait-NodeCompliance
 {
-    [CmdletBinding()]     
+    [CmdletBinding()]
     param
     (
         [string]$ResourceGroupName = 'TestAutomation'+$env:BuildID,
         [string]$AutomationAccountName = 'AADSC'+$env:BuildID
     )
-    try 
+    try
     {
         $Nodes = Get-AzureRMAutomationDSCNode -ResourceGroupName $ResourceGroupName `
         -AutomationAccountName $AutomationAccountName
@@ -589,9 +589,9 @@ function Wait-NodeCompliance
             }
         }
     }
-    catch [System.Exception] 
+    catch [System.Exception]
     {
-        throw "An error occured while waiting nodes to report compliance status in Azure Automation`n$($_.exception.message)"        
+        throw "An error occured while waiting nodes to report compliance status in Azure Automation`n$($_.exception.message)"
     }
 }
 


### PR DESCRIPTION
- Changes to DscConfiguration.Tests
  - Fixed so the correct path is used for property WindowsOSVersion in the module manifest (issue #24).
  - Pester test result file is only uploaded if the test are running in AppVeyor (issue #26).
  - The Pester test result file is removed after the file has been uploaded (issue #26).
  - Fixed so that latest Pester version can be installed on a Windows 10 or Windows Server 2016 where Pester module is signed (issue #29).
  - Fixed so that more than one required module can be loaded (issue #32).

_Sorry for the white space changes. I have VS Code automatic trimming white spaces._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscconfiguration.tests/34)
<!-- Reviewable:end -->
